### PR TITLE
Captain/Spotter Refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,6 +172,7 @@ cython_debug/
 # MacOS
 .DS_Store
 
+experiments/collaborative/captain_benchmarks/
 experiments/collaborative/data/
 experiments/prolific/battleship/.empirica/empirica.toml
 experiments/prolific/battleship/package-lock.json

--- a/battleship/agents.py
+++ b/battleship/agents.py
@@ -133,8 +133,6 @@ class Agent(ABC):
         decision_counter: Counter = None,
         index_counter: Counter = None,
         round_id: str = None,
-        stage_dir: str = None,
-        prompts_dir: str = None,
     ):
         self.round_id = round_id
         self.use_cot = use_cot
@@ -144,8 +142,6 @@ class Agent(ABC):
         self.index_counter = index_counter
         self.stage_list = []
         self.prompt_list = []
-        self.stage_dir = stage_dir
-        self.prompts_dir = prompts_dir
 
 
 class EIGCalculator:

--- a/battleship/agents.py
+++ b/battleship/agents.py
@@ -49,10 +49,14 @@ class ActionData:
     map_prob: float = None  # For MAP calculations
     occ_tiles: np.ndarray = None  # Board state at time of action
 
+    def __post_init__(self):
+        if self.timestamp is None:
+            self.timestamp = time.time()
+
     def to_dict(self) -> dict:
         """Convert action data to dictionary format for JSON serialization."""
         return {
-            "index": self.index,
+            "index": int(self.index),  # Convert numpy.int64 to Python int
             "action": self.action,
             "prompt": self.prompt,
             "completion": self.completion,
@@ -60,13 +64,21 @@ class ActionData:
             "question": self.question.to_dict() if self.question else None,
             "answer": self.answer.to_dict() if self.answer else None,
             "decision": self.decision,
-            "move": self.move,
-            "timestamp": self.timestamp,
-            "eig": self.eig,
-            "map_prob": self.map_prob,
-            "occ_tiles": self.occ_tiles.tolist()
+            "move": tuple(int(x) for x in self.move)
+            if self.move
+            else None,  # Convert numpy.int64 to Python int
+            "timestamp": float(self.timestamp)
+            if self.timestamp
+            else None,  # Convert numpy.float64 to Python float
+            "eig": float(self.eig)
+            if self.eig is not None
+            else None,  # Convert numpy.float64 to Python float
+            "map_prob": float(self.map_prob)
+            if self.map_prob is not None
+            else None,  # Convert numpy.float64 to Python float
+            "occ_tiles": self.occ_tiles.astype(int).tolist()
             if self.occ_tiles is not None
-            else None,
+            else None,  # Convert numpy array to Python list
         }
 
     @classmethod

--- a/battleship/agents.py
+++ b/battleship/agents.py
@@ -59,7 +59,7 @@ class ActionData:
     def to_dict(self) -> dict:
         """Convert action data to dictionary format for JSON serialization."""
         return {
-            "stage_index": int(self.index),  # Convert numpy.int64 to Python int
+            "stage_index": int(self.stage_index),  # Convert numpy.int64 to Python int
             "action": self.action,
             "prompt": self.prompt,
             "completion": self.completion,
@@ -245,7 +245,7 @@ class Agent(ABC):
             data = []
 
         # Add stage index to action data
-        action_data.index = self.stage_index
+        action_data.stage_index = self.stage_index
 
         # Add new action
         data.append(action_data.to_dict())

--- a/battleship/agents.py
+++ b/battleship/agents.py
@@ -146,16 +146,20 @@ class Answer:
 class CodeQuestion:
     def __init__(
         self,
-        question: str,
+        question: Question,
         fn_text: str,
-        translation_prompt,
-        full_completion,
+        translation_prompt: str,
+        completion: dict,
     ):
+        if not isinstance(question, Question):
+            raise ValueError(
+                f"question must be an instance of Question, got {type(question)}"
+            )
+
         self.question = question
         self.fn_str = fn_text
         self.translation_prompt = translation_prompt
-        self.full_completion = full_completion
-
+        self.completion = completion
         self.__evaluate_fn_text()
 
     def __evaluate_fn_text(self):
@@ -186,10 +190,10 @@ class CodeQuestion:
 
     def to_dict(self) -> dict:
         return {
-            "question": self.question,
+            "question": self.question.to_dict(),
             "fn_str": self.fn_str,
             "translation_prompt": str(self.translation_prompt),
-            "full_completion": self.full_completion,
+            "completion": self.completion,
         }
 
     @classmethod
@@ -198,17 +202,17 @@ class CodeQuestion:
             question=data["question"],
             fn_text=data["fn_str"],
             translation_prompt=data["translation_prompt"],
-            full_completion=data["full_completion"],
+            completion=data["completion"],
         )
 
 
 class NullCodeQuestion(CodeQuestion):
-    def __init__(self, translation_prompt):
-        self.question = None
+    def __init__(self, question, translation_prompt):
+        self.question = question
         self.fn = lambda true_board, partial_board: None
         self.fn_str = None
         self.translation_prompt = translation_prompt
-        self.full_completion = None
+        self.completion = None
 
 
 # ---------------------
@@ -275,9 +279,9 @@ class EIGCalculator:
         )
 
         results = {"yes": 0, "no": 0}
-        curr_time = time()
+        curr_time = time.time()
         while sum(results.values()) < samples:
-            if time() - curr_time > 15:
+            if time.time() - curr_time > 15:
                 return float("nan")
             board = None
             while not board:

--- a/battleship/captains.py
+++ b/battleship/captains.py
@@ -63,7 +63,6 @@ class Captain(Agent):
         moves_remaining: int,
         sunk: str,
     ) -> Decision:
-        self.decision_counter.increment_counter()
         self.questions_remaining = questions_remaining
         self.moves_remaining = moves_remaining
         decision, action_data = self.decision_strategy.make_decision(
@@ -109,7 +108,6 @@ class Captain(Agent):
 class AlwaysMoveDecisionStrategy(DecisionStrategy):
     def make_decision(self, state, history, questions_remaining, moves_remaining, sunk):
         action_data = ActionData(
-            index=self.index_counter.increment_counter() if self.index_counter else 0,
             action="decision",
             decision=Decision.MOVE,
         )
@@ -128,7 +126,6 @@ class ProbabilisticDecisionStrategy(DecisionStrategy):
             decision = Decision.MOVE
 
         action_data = ActionData(
-            index=self.index_counter.increment_counter() if self.index_counter else 0,
             action="decision",
             decision=decision,
         )
@@ -141,11 +138,8 @@ class LLMDecisionStrategy(DecisionStrategy):
         model_string,
         temperature=None,
         use_cot=False,
-        index_counter=None,
     ):
-        super().__init__(
-            index_counter=index_counter,
-        )
+        super().__init__()
         self.model_string = model_string
         self.temperature = temperature
         self.use_cot = use_cot
@@ -188,7 +182,6 @@ class LLMDecisionStrategy(DecisionStrategy):
 
         # Create an ActionData object to store the interaction
         action_data = ActionData(
-            index=self.index_counter.increment_counter(),
             action="decision",
             prompt=str(decision_prompt),
             completion=completion.model_dump() if completion else None,
@@ -212,7 +205,6 @@ class RandomMoveStrategy(MoveStrategy):
         coords = self.rng.choice(hidden_tiles)
 
         action_data = ActionData(
-            index=self.index_counter.increment_counter() if self.index_counter else 0,
             action="move",
             move=coords,
         )
@@ -264,7 +256,6 @@ class MAPMoveStrategy(MoveStrategy):
         move = tuple(move_coords)
 
         action_data = ActionData(
-            index=self.index_counter.increment_counter() if self.index_counter else 0,
             action="move",
             move=move,
             map_prob=float(posterior.max()),
@@ -280,11 +271,8 @@ class LLMMoveStrategy(MoveStrategy):
         use_cot=False,
         moves_remaining=None,
         n_attempts=3,
-        index_counter=None,
     ):
-        super().__init__(
-            index_counter=index_counter,
-        )
+        super().__init__()
         self.model_string = model_string
         self.temperature = temperature
         self.use_cot = use_cot
@@ -323,7 +311,6 @@ class LLMMoveStrategy(MoveStrategy):
                 if candidate_move not in visible_tiles:
                     # Create an ActionData object to store the interaction
                     action_data = ActionData(
-                        index=self.index_counter.increment_counter(),
                         action="move",
                         prompt=str(move_prompt),
                         completion=completion.model_dump(),
@@ -334,7 +321,6 @@ class LLMMoveStrategy(MoveStrategy):
 
         # If no valid move found, return None with ActionData
         action_data = ActionData(
-            index=self.index_counter.increment_counter(),
             action="move",
             prompt=str(move_prompt),
             completion=completion.model_dump() if completion else None,
@@ -355,11 +341,8 @@ class EIGQuestionStrategy(QuestionStrategy):
         use_cot=False,
         questions_remaining=None,
         n_attempts=3,
-        index_counter=None,
     ):
-        super().__init__(
-            index_counter=index_counter,
-        )
+        super().__init__()
         self.model_string = model_string
         self.spotter = spotter
         self.rng = rng
@@ -414,7 +397,6 @@ class EIGQuestionStrategy(QuestionStrategy):
 
             # Create an ActionData object to store the interaction
             action_data = ActionData(
-                index=self.index_counter.increment_counter(),
                 action="question",
                 prompt=str(question_prompt),
                 full_completion=completion.choices[0].message.content
@@ -444,11 +426,8 @@ class LLMQuestionStrategy(QuestionStrategy):
         rng=None,
         questions_remaining=None,
         n_attempts=3,
-        index_counter=None,
     ):
-        super().__init__(
-            index_counter=index_counter,
-        )
+        super().__init__()
         self.model_string = model_string
         self.temperature = temperature
         self.use_cot = use_cot
@@ -488,7 +467,6 @@ class LLMQuestionStrategy(QuestionStrategy):
 
                 # Create an ActionData object to store the interaction
                 action_data = ActionData(
-                    index=self.index_counter.increment_counter(),
                     action="question",
                     prompt=str(question_prompt),
                     full_completion=completion.choices[0].message.content,
@@ -500,7 +478,6 @@ class LLMQuestionStrategy(QuestionStrategy):
 
         # If no valid question found, return None with ActionData
         action_data = ActionData(
-            index=self.index_counter.increment_counter(),
             action="question",
             prompt=str(question_prompt),
             full_completion=completion.choices[0].message.content
@@ -524,7 +501,6 @@ def create_captain(
     round_id=None,
     json_path=None,
     completions_dir=None,
-    index_counter=None,
 ):
     """
     Factory function to create Captain instances with properly configured strategies.
@@ -571,12 +547,10 @@ def create_captain(
             move_strategy=LLMMoveStrategy(
                 model_string=model,
                 use_cot=False,
-                index_counter=index_counter,
             ),
             question_strategy=LLMQuestionStrategy(
                 model_string=model,
                 use_cot=False,
-                index_counter=index_counter,
             ),
             seed=seed,
             model_string=model,
@@ -591,12 +565,10 @@ def create_captain(
             move_strategy=LLMMoveStrategy(
                 model_string=model,
                 use_cot=True,
-                index_counter=index_counter,
             ),
             question_strategy=LLMQuestionStrategy(
                 model_string=model,
                 use_cot=True,
-                index_counter=index_counter,
             ),
             seed=seed,
             model_string=model,
@@ -610,17 +582,14 @@ def create_captain(
             decision_strategy=LLMDecisionStrategy(
                 model_string=model,
                 use_cot=False,
-                index_counter=index_counter,
             ),
             move_strategy=LLMMoveStrategy(
                 model_string=model,
                 use_cot=False,
-                index_counter=index_counter,
             ),
             question_strategy=LLMQuestionStrategy(
                 model_string=model,
                 use_cot=False,
-                index_counter=index_counter,
                 spotter=_get_spotter(),
                 rng=np.random.default_rng(seed),
             ),
@@ -636,17 +605,14 @@ def create_captain(
             decision_strategy=LLMDecisionStrategy(
                 model_string=model,
                 use_cot=True,
-                index_counter=index_counter,
             ),
             move_strategy=LLMMoveStrategy(
                 model_string=model,
                 use_cot=True,
-                index_counter=index_counter,
             ),
             question_strategy=LLMQuestionStrategy(
                 model_string=model,
                 use_cot=True,
-                index_counter=index_counter,
                 spotter=_get_spotter(),
                 rng=np.random.default_rng(seed),
             ),
@@ -662,12 +628,10 @@ def create_captain(
             decision_strategy=LLMDecisionStrategy(
                 model_string=model,
                 use_cot=False,
-                index_counter=index_counter,
             ),
             move_strategy=LLMMoveStrategy(
                 model_string=model,
                 use_cot=False,
-                index_counter=index_counter,
             ),
             question_strategy=EIGQuestionStrategy(
                 model_string=model,
@@ -676,7 +640,6 @@ def create_captain(
                 samples=eig_samples,
                 k=eig_k,
                 use_cot=False,
-                index_counter=index_counter,
             ),
             seed=seed,
             model_string=model,
@@ -690,12 +653,10 @@ def create_captain(
             decision_strategy=LLMDecisionStrategy(
                 model_string=model,
                 use_cot=True,
-                index_counter=index_counter,
             ),
             move_strategy=LLMMoveStrategy(
                 model_string=model,
                 use_cot=True,
-                index_counter=index_counter,
             ),
             question_strategy=EIGQuestionStrategy(
                 model_string=model,
@@ -704,7 +665,6 @@ def create_captain(
                 samples=eig_samples,
                 k=eig_k,
                 use_cot=True,
-                index_counter=index_counter,
             ),
             seed=seed,
             model_string=model,
@@ -718,7 +678,6 @@ def create_captain(
             decision_strategy=LLMDecisionStrategy(
                 model_string=model,
                 use_cot=False,
-                index_counter=index_counter,
             ),
             move_strategy=MAPMoveStrategy(
                 rng=np.random.default_rng(seed),
@@ -732,7 +691,6 @@ def create_captain(
                 samples=eig_samples,
                 k=eig_k,
                 use_cot=False,
-                index_counter=index_counter,
             ),
             seed=seed,
             model_string=model,
@@ -746,7 +704,6 @@ def create_captain(
             decision_strategy=LLMDecisionStrategy(
                 model_string=model,
                 use_cot=True,
-                index_counter=index_counter,
             ),
             move_strategy=MAPMoveStrategy(
                 rng=np.random.default_rng(seed),
@@ -760,7 +717,6 @@ def create_captain(
                 samples=eig_samples,
                 k=eig_k,
                 use_cot=True,
-                index_counter=index_counter,
             ),
             seed=seed,
             model_string=model,

--- a/battleship/captains.py
+++ b/battleship/captains.py
@@ -191,12 +191,14 @@ class LLMDecisionStrategy(DecisionStrategy):
             )
 
         else:
+            completion = None
+            decision_prompt = None
             decision = Decision.MOVE
 
         # Create an ActionData object to store the interaction
         action_data = ActionData(
             action="decision",
-            prompt=str(decision_prompt),
+            prompt=str(decision_prompt) if decision_prompt else None,
             completion=completion.model_dump() if completion else None,
             decision=decision,
         )
@@ -408,10 +410,7 @@ class EIGQuestionStrategy(QuestionStrategy):
             action_data = ActionData(
                 action="question",
                 prompt=str(question_prompt),
-                full_completion=completion.choices[0].message.content
-                if completion
-                else None,
-                completion_id=completion.id if completion else None,
+                completion=completion.model_dump(),
                 question=candidate_question,
                 eig=eig,
             )
@@ -476,8 +475,8 @@ class LLMQuestionStrategy(QuestionStrategy):
                 action_data = ActionData(
                     action="question",
                     prompt=str(question_prompt),
-                    full_completion=completion.choices[0].message.content,
-                    completion_id=completion.id,
+                    completion=completion.model_dump(),
+                    extracted_completion=candidate_question,
                     question=question,
                 )
 
@@ -487,10 +486,8 @@ class LLMQuestionStrategy(QuestionStrategy):
         action_data = ActionData(
             action="question",
             prompt=str(question_prompt),
-            full_completion=completion.choices[0].message.content
-            if completion
-            else None,
-            completion_id=completion.id if completion else None,
+            completion=completion.model_dump() if completion else None,
+            extracted_completion=None,
             question=None,
         )
         return None, action_data

--- a/battleship/captains.py
+++ b/battleship/captains.py
@@ -238,10 +238,10 @@ class RandomMoveStrategy(MoveStrategy):
 
 
 class MAPMoveStrategy(MoveStrategy):
-    def __init__(self, rng, n_samples=1000, board_id=None):
+    def __init__(self, rng, board_id, n_samples=1000):
         self.rng = rng
-        self.n_samples = n_samples
         self.board_id = board_id
+        self.n_samples = n_samples
 
     def make_move(
         self, state, history, sunk, questions_remaining, moves_remaining, constraints
@@ -520,10 +520,14 @@ def create_captain(
     seed,
     model,
     use_cache,
+    board_id,
     map_samples=None,
     prob_q_prob=None,
     eig_samples=None,
     eig_k=None,
+    round_id=None,
+    stage_dir=None,
+    prompts_dir=None,
 ):
     """
     Factory function to create Captain instances with properly configured strategies.
@@ -533,7 +537,7 @@ def create_captain(
     # Initialize spotter for EIG captains
     def _get_spotter():
         return CodeSpotterModel(
-            board_id="B01",
+            board_id=board_id,
             board_experiment="collaborative",
             model_string=model,
             temperature=None,
@@ -547,19 +551,25 @@ def create_captain(
             question_strategy=None,
             seed=seed,
             use_cache=use_cache,
-            round_id=None,
+            round_id=round_id,
+            stage_dir=stage_dir,
+            prompts_dir=prompts_dir,
         )
 
     elif captain_type == "MAPCaptain":
         return Captain(
             decision_strategy=AlwaysMoveDecisionStrategy(),
             move_strategy=MAPMoveStrategy(
-                rng=np.random.default_rng(seed), n_samples=map_samples
+                rng=np.random.default_rng(seed),
+                board_id=board_id,
+                n_samples=map_samples,
             ),
             question_strategy=None,
             seed=seed,
             use_cache=use_cache,
-            round_id=None,
+            round_id=round_id,
+            stage_dir=stage_dir,
+            prompts_dir=prompts_dir,
         )
 
     elif captain_type == "ProbabilisticCaptain":
@@ -570,7 +580,9 @@ def create_captain(
             seed=seed,
             model_string=model,
             use_cache=use_cache,
-            round_id=None,
+            round_id=round_id,
+            stage_dir=stage_dir,
+            prompts_dir=prompts_dir,
         )
         return captain
 
@@ -586,7 +598,9 @@ def create_captain(
             seed=seed,
             model_string=model,
             use_cache=use_cache,
-            round_id=None,
+            round_id=round_id,
+            stage_dir=stage_dir,
+            prompts_dir=prompts_dir,
         )
         return captain
 
@@ -606,7 +620,9 @@ def create_captain(
             seed=seed,
             model_string=model,
             use_cache=use_cache,
-            round_id=None,
+            round_id=round_id,
+            stage_dir=stage_dir,
+            prompts_dir=prompts_dir,
         )
         return captain
 
@@ -623,7 +639,9 @@ def create_captain(
             seed=seed,
             model_string=model,
             use_cache=use_cache,
-            round_id=None,
+            round_id=round_id,
+            stage_dir=stage_dir,
+            prompts_dir=prompts_dir,
         )
         return captain
 
@@ -642,7 +660,9 @@ def create_captain(
             seed=seed,
             model_string=model,
             use_cache=use_cache,
-            round_id=None,
+            round_id=round_id,
+            stage_dir=stage_dir,
+            prompts_dir=prompts_dir,
         )
         return captain
 
@@ -665,7 +685,9 @@ def create_captain(
             seed=seed,
             model_string=model,
             use_cache=use_cache,
-            round_id=None,
+            round_id=round_id,
+            stage_dir=stage_dir,
+            prompts_dir=prompts_dir,
         )
         return captain
 
@@ -673,7 +695,9 @@ def create_captain(
         captain = Captain(
             decision_strategy=LLMDecisionStrategy(model_string=model, use_cot=False),
             move_strategy=MAPMoveStrategy(
-                rng=np.random.default_rng(seed), n_samples=eig_samples
+                rng=np.random.default_rng(seed),
+                board_id=board_id,
+                n_samples=eig_samples,
             ),
             question_strategy=EIGQuestionStrategy(
                 model_string=model,
@@ -686,7 +710,9 @@ def create_captain(
             seed=seed,
             model_string=model,
             use_cache=use_cache,
-            round_id=None,
+            round_id=round_id,
+            stage_dir=stage_dir,
+            prompts_dir=prompts_dir,
         )
         return captain
 
@@ -694,7 +720,9 @@ def create_captain(
         captain = Captain(
             decision_strategy=LLMDecisionStrategy(model_string=model, use_cot=True),
             move_strategy=MAPMoveStrategy(
-                rng=np.random.default_rng(seed), n_samples=eig_samples
+                rng=np.random.default_rng(seed),
+                board_id=board_id,
+                n_samples=eig_samples,
             ),
             question_strategy=EIGQuestionStrategy(
                 model_string=model,
@@ -707,7 +735,9 @@ def create_captain(
             seed=seed,
             model_string=model,
             use_cache=use_cache,
-            round_id=None,
+            round_id=round_id,
+            stage_dir=stage_dir,
+            prompts_dir=prompts_dir,
         )
         return captain
 

--- a/battleship/captains.py
+++ b/battleship/captains.py
@@ -59,15 +59,11 @@ class Captain(Agent):
         model_string=None,
         temperature=None,
         round_id=None,
-        stage_dir=None,
-        prompts_dir=None,
     ):
         super().__init__(
             seed=seed,
             model_string=model_string,
             round_id=round_id,
-            stage_dir=stage_dir,
-            prompts_dir=prompts_dir,
         )
         self.temperature = temperature
         self.sampling_constraints = []
@@ -410,8 +406,6 @@ def create_captain(
     eig_samples=None,
     eig_k=None,
     round_id=None,
-    stage_dir=None,
-    prompts_dir=None,
 ):
     """
     Factory function to create Captain instances with properly configured strategies.
@@ -435,8 +429,6 @@ def create_captain(
             question_strategy=None,
             seed=seed,
             round_id=round_id,
-            stage_dir=stage_dir,
-            prompts_dir=prompts_dir,
         )
 
     elif captain_type == "MAPCaptain":
@@ -450,8 +442,6 @@ def create_captain(
             question_strategy=None,
             seed=seed,
             round_id=round_id,
-            stage_dir=stage_dir,
-            prompts_dir=prompts_dir,
         )
 
     elif captain_type == "ProbabilisticCaptain":
@@ -462,8 +452,6 @@ def create_captain(
             seed=seed,
             model_string=model,
             round_id=round_id,
-            stage_dir=stage_dir,
-            prompts_dir=prompts_dir,
         )
         return captain
 
@@ -479,8 +467,6 @@ def create_captain(
             seed=seed,
             model_string=model,
             round_id=round_id,
-            stage_dir=stage_dir,
-            prompts_dir=prompts_dir,
         )
         return captain
 
@@ -500,8 +486,6 @@ def create_captain(
             seed=seed,
             model_string=model,
             round_id=round_id,
-            stage_dir=stage_dir,
-            prompts_dir=prompts_dir,
         )
         return captain
 
@@ -518,8 +502,6 @@ def create_captain(
             seed=seed,
             model_string=model,
             round_id=round_id,
-            stage_dir=stage_dir,
-            prompts_dir=prompts_dir,
         )
         return captain
 
@@ -538,8 +520,6 @@ def create_captain(
             seed=seed,
             model_string=model,
             round_id=round_id,
-            stage_dir=stage_dir,
-            prompts_dir=prompts_dir,
         )
         return captain
 
@@ -562,8 +542,6 @@ def create_captain(
             seed=seed,
             model_string=model,
             round_id=round_id,
-            stage_dir=stage_dir,
-            prompts_dir=prompts_dir,
         )
         return captain
 
@@ -586,8 +564,6 @@ def create_captain(
             seed=seed,
             model_string=model,
             round_id=round_id,
-            stage_dir=stage_dir,
-            prompts_dir=prompts_dir,
         )
         return captain
 
@@ -610,8 +586,6 @@ def create_captain(
             seed=seed,
             model_string=model,
             round_id=round_id,
-            stage_dir=stage_dir,
-            prompts_dir=prompts_dir,
         )
         return captain
 

--- a/battleship/game.py
+++ b/battleship/game.py
@@ -50,7 +50,7 @@ class BattleshipGame:
         self.max_questions = max_questions
         self.max_moves = max_moves
 
-        self.stage_count = 0
+        self.stage_index = 0
         self.question_count = 0
         self.move_count = 0
 
@@ -65,12 +65,12 @@ class BattleshipGame:
             self.save_path = None
 
     def __len__(self):
-        return self.stage_count
+        return self.stage_index
 
     def __repr__(self):
         return (
             f"BattleshipGame(\n"
-            f"  stage={self.stage_count},\n"
+            f"  stage={self.stage_index},\n"
             f"  hits={self.hits},\n"
             f"  misses={self.misses},\n"
             f"  questions={self.question_count}/{self.max_questions},\n"
@@ -137,7 +137,7 @@ class BattleshipGame:
             self.question_count += 1
             self.history.append(
                 {
-                    "stage": self.stage_count,
+                    "stage": self.stage_index,
                     "decision": Decision.QUESTION,
                     "question": q,
                     "answer": a,
@@ -158,7 +158,7 @@ class BattleshipGame:
             self.move_count += 1
             self.history.append(
                 {
-                    "stage": self.stage_count,
+                    "stage": self.stage_index,
                     "decision": Decision.MOVE,
                     "coords": tuple(int(x) for x in coords),
                     "state": self.state.board.tolist(),
@@ -167,7 +167,9 @@ class BattleshipGame:
         else:
             raise ValueError(f"Invalid decision: {decision}")
 
-        self.stage_count += 1
+        self.stage_index += 1
+        self.captain.stage_index += 1
+        self.spotter.stage_index += 1
 
     def update_state(self, coords: Tuple[int, int]):
         if self.state.board[coords].item() != Board.hidden:
@@ -197,4 +199,4 @@ class BattleshipGame:
             return
 
         with open(self.save_path, "w") as f:
-            json.dump(self.history, f, indent=4)
+            json.dump(self.history, f, indent=2)

--- a/battleship/game.py
+++ b/battleship/game.py
@@ -127,7 +127,13 @@ class BattleshipGame:
         )
 
         if decision == Decision.QUESTION:
-            q = self.captain.question(self.state, self.history, sunk_string)
+            q = self.captain.question(
+                self.state,
+                self.history,
+                sunk_string,
+                questions_remaining=self.max_questions - self.question_count,
+                moves_remaining=self.max_moves - self.move_count,
+            )
             a = self.spotter.answer(
                 question=q, occ_tiles=self.state.board, history=self.history
             )
@@ -149,7 +155,9 @@ class BattleshipGame:
                 self.state,
                 self.history,
                 sunk_string,
-                self.captain.sampling_constraints,
+                questions_remaining=self.max_questions - self.question_count,
+                moves_remaining=self.max_moves - self.move_count,
+                constraints=self.captain.sampling_constraints,
             )
 
             if coords is not None:

--- a/battleship/game.py
+++ b/battleship/game.py
@@ -145,8 +145,8 @@ class BattleshipGame:
                 {
                     "stage": self.stage_index,
                     "decision": Decision.QUESTION,
-                    "question": q,
-                    "answer": a,
+                    "question": q.to_dict(),
+                    "answer": a.to_dict(),
                     "state": self.state.board.tolist(),
                 }
             )

--- a/battleship/game.py
+++ b/battleship/game.py
@@ -141,6 +141,7 @@ class BattleshipGame:
                     "decision": Decision.QUESTION,
                     "question": q,
                     "answer": a,
+                    "state": self.state.board.tolist(),
                 }
             )
         elif decision == Decision.MOVE:
@@ -159,9 +160,8 @@ class BattleshipGame:
                 {
                     "stage": self.stage_count,
                     "decision": Decision.MOVE,
-                    "coords": tuple(int(x) for x in coords)
-                    if coords is not None
-                    else None,
+                    "coords": tuple(int(x) for x in coords),
+                    "state": self.state.board.tolist(),
                 }
             )
         else:

--- a/battleship/prompting.py
+++ b/battleship/prompting.py
@@ -106,12 +106,12 @@ class BasePrompt(object):
             if example["decision"] == Decision.QUESTION:
                 # TODO: Implement dataloader for human data to make this cleaner
                 question_text = (
-                    example["question"].text
+                    example["question"]["text"]
                     if type(example["question"]) != str
                     else example["question"]
                 )
                 answer_text = (
-                    example["answer"].text
+                    example["answer"]["text"]
                     if type(example["answer"]) != str
                     else example["answer"]
                 )

--- a/battleship/run_captain_benchmarks.py
+++ b/battleship/run_captain_benchmarks.py
@@ -144,6 +144,9 @@ def run_single_agent_game(args):
         eig_k,
     ) = args
 
+    print(f"{captain_type} started with {board_id} & seed {seed}")
+    board = Board.from_trial_id(board_id)
+
     captain = create_captain(
         captain_type=captain_type,
         seed=seed,
@@ -158,9 +161,6 @@ def run_single_agent_game(args):
         stage_dir=STAGE_DIR,
         prompts_dir=PROMPTS_DIR,
     )
-
-    print(f"{captain_type} started with {board_id} & seed {seed}")
-    board = Board.from_trial_id(board_id)
 
     decision_counter = Counter()
     index_counter = Counter()
@@ -205,7 +205,6 @@ def run_single_agent_game(args):
         save_dir=str(game_save_dir),
     )
     game.play()
-    # Save game history to file
     game.save()
     print(f"{captain_type} finished with {board_id} & seed {seed}")
 

--- a/battleship/run_captain_benchmarks.py
+++ b/battleship/run_captain_benchmarks.py
@@ -137,7 +137,6 @@ def run_single_agent_game(args):
         ROUND_RESULTS_DIR,
         STAGE_DIR,
         PROMPTS_DIR,
-        use_cache,
         map_samples,
         prob_q_prob,
         eig_samples,
@@ -152,7 +151,6 @@ def run_single_agent_game(args):
         seed=seed,
         model=model,
         board_id=board_id,
-        use_cache=use_cache,
         map_samples=map_samples,
         prob_q_prob=prob_q_prob,
         eig_samples=eig_samples,
@@ -172,7 +170,6 @@ def run_single_agent_game(args):
     spotter = CodeSpotterModel(
         board_id,
         "collaborative",
-        use_cache=True,
         model_string=model,
         temperature=None,
         use_cot=True,
@@ -300,7 +297,6 @@ def main():
                         ROUND_RESULTS_DIR,
                         STAGE_DIR,
                         PROMPTS_DIR,
-                        args.use_cache,
                         args.map_samples,
                         args.prob_q_prob,
                         args.eig_samples,
@@ -385,7 +381,6 @@ def parse_arguments():
 
     # Model configuration
     parser.add_argument("--model", type=str, default="gpt-4o", help="LLM model to use")
-    parser.add_argument("--use-cache", action="store_true", help="Cache results")
 
     # Experiment settings
     parser.add_argument(

--- a/battleship/run_captain_benchmarks.py
+++ b/battleship/run_captain_benchmarks.py
@@ -12,7 +12,6 @@ from typing import Tuple
 import numpy as np
 import pandas as pd
 
-from battleship.agents import Counter
 from battleship.board import Board
 from battleship.captains import create_captain
 from battleship.game import BattleshipGame
@@ -124,11 +123,6 @@ def run_single_agent_game(args):
     os.makedirs(captain_dir, exist_ok=True)
     os.makedirs(spotter_dir, exist_ok=True)
 
-    # Initialize counters for tracking completions
-    completion_counter = Counter()
-    decision_counter = Counter()
-    index_counter = Counter()
-
     captain = create_captain(
         captain_type=captain_type,
         seed=seed,
@@ -142,10 +136,6 @@ def run_single_agent_game(args):
         json_path=os.path.join(captain_dir, "captain.json"),
     )
 
-    # Set runtime counters
-    captain.index_counter = index_counter
-    captain.decision_counter = decision_counter
-
     spotter = create_spotter(
         spotter_type="CodeSpotterModel",
         board_id=board_id,
@@ -153,8 +143,6 @@ def run_single_agent_game(args):
         model_string=model,
         temperature=None,
         use_cot=True,
-        decision_counter=decision_counter,
-        index_counter=index_counter,
         round_id=round_id,
         json_path=os.path.join(spotter_dir, "spotter.json"),
     )

--- a/battleship/run_captain_benchmarks.py
+++ b/battleship/run_captain_benchmarks.py
@@ -16,7 +16,7 @@ from battleship.agents import Counter
 from battleship.board import Board
 from battleship.captains import create_captain
 from battleship.game import BattleshipGame
-from battleship.spotters import CodeSpotterModel
+from battleship.spotters import create_spotter
 from battleship.utils import resolve_project_path
 
 
@@ -119,14 +119,10 @@ def run_single_agent_game(args):
     round_dir = os.path.join(experiment_dir, "rounds", f"round_{round_id}")
     captain_dir = os.path.join(round_dir, "captain")
     spotter_dir = os.path.join(round_dir, "spotter")
-    captain_completions_dir = os.path.join(captain_dir, "completions")
-    spotter_completions_dir = os.path.join(spotter_dir, "completions")
 
     os.makedirs(round_dir, exist_ok=True)
     os.makedirs(captain_dir, exist_ok=True)
     os.makedirs(spotter_dir, exist_ok=True)
-    os.makedirs(captain_completions_dir, exist_ok=True)
-    os.makedirs(spotter_completions_dir, exist_ok=True)
 
     # Initialize counters for tracking completions
     completion_counter = Counter()
@@ -144,17 +140,16 @@ def run_single_agent_game(args):
         eig_k=eig_k,
         round_id=round_id,
         json_path=os.path.join(captain_dir, "captain.json"),
-        completions_dir=captain_completions_dir,
     )
 
     # Set runtime counters
     captain.index_counter = index_counter
     captain.decision_counter = decision_counter
-    captain.completion_counter = completion_counter
 
-    spotter = CodeSpotterModel(
-        board_id,
-        "collaborative",
+    spotter = create_spotter(
+        spotter_type="CodeSpotterModel",
+        board_id=board_id,
+        board_experiment="collaborative",
         model_string=model,
         temperature=None,
         use_cot=True,
@@ -162,7 +157,6 @@ def run_single_agent_game(args):
         index_counter=index_counter,
         round_id=round_id,
         json_path=os.path.join(spotter_dir, "spotter.json"),
-        completions_dir=spotter_completions_dir,
     )
 
     game = BattleshipGame(

--- a/battleship/run_spotter_benchmarks.py
+++ b/battleship/run_spotter_benchmarks.py
@@ -191,7 +191,6 @@ def process_question_data(question_data):
         model_string,
         temperature,
         use_history,
-        use_cache,
         use_cot,
         use_captain_board,
         output_dir,
@@ -212,7 +211,6 @@ def process_question_data(question_data):
     spotter_model = model_class(
         board_id=question_board,
         board_experiment="collaborative",
-        use_cache=use_cache,
         model_string=model_string,
         temperature=temperature,
         use_cot=use_cot,
@@ -222,7 +220,7 @@ def process_question_data(question_data):
     )
 
     question = Question(text=question_text)
-    result, answer_cache = spotter_model.answer(
+    result = spotter_model.answer(
         question,
         occ_tiles=Board.from_occ_tiles(question_captain_board).to_numpy(),
         history=examples if use_history else None,
@@ -250,8 +248,6 @@ def process_question_data(question_data):
         )
         if result.code_question
         else None,
-        "full_completion": answer_cache.prompts[-1].full_completion,
-        "prompt": answer_cache.prompts[-1].prompt,
         "true_answer": ground_truth_answer,
         "is_correct": answer_text == ground_truth_answer,
     }
@@ -284,7 +280,6 @@ def prepare_question_data(
     use_history,
     max_rounds,
     max_questions,
-    use_cache,
     use_cot,
     use_captain_board,
     output_dir,
@@ -320,7 +315,6 @@ def prepare_question_data(
                     model_string,
                     temperature,
                     use_history,
-                    use_cache,
                     use_cot,
                     use_captain_board,
                     output_dir,
@@ -339,7 +333,6 @@ def benchmark_on_rounds(
     use_history=False,
     max_rounds=10,
     max_questions=10,
-    use_cache=True,
     use_cot=False,
     use_captain_board=False,
     output_dir="benchmark_results",
@@ -360,7 +353,6 @@ def benchmark_on_rounds(
         use_history,
         max_rounds,
         max_questions,
-        use_cache,
         use_cot,
         use_captain_board,
         output_dir,
@@ -406,7 +398,6 @@ def run_experiments(
     max_rounds=20,
     max_questions=20,
     use_history=True,
-    use_cache=False,
     use_captain_board=False,
     output_dir="benchmark_results",
 ):
@@ -427,7 +418,6 @@ def run_experiments(
                     model_string=llm,
                     max_rounds=max_rounds,
                     max_questions=max_questions,
-                    use_cache=use_cache,
                     use_cot=cot_option,
                     use_history=use_history,
                     use_captain_board=use_captain_board,
@@ -435,21 +425,6 @@ def run_experiments(
                 )
 
                 results.append(result_name)
-
-                # result_dict = {
-                #     "language_model": llm,
-                #     "spotter_model": spotter.__name__,
-                #     "cot": cot_option,
-                #     "accuracy": accuracy,
-                #     "max_rounds": max_rounds,
-                #     "max_questions": max_questions,
-                #     "use_history": use_history,
-                #     "use_cache": use_cache,
-                #     "use_captain_board": use_captain_board,
-                # }
-                # results.append(result_dict)
-
-                # print(f"Accuracy: {accuracy * 100:.2f}%")
 
     return results
 
@@ -512,11 +487,6 @@ if __name__ == "__main__":
         help="Flag to include history in the benchmark.",
     )
     parser.add_argument(
-        "--use_cache",
-        action="store_true",
-        help="Flag to enable cache usage.",
-    )
-    parser.add_argument(
         "--use_captain_board",
         action="store_true",
         help="Flag to use captain board in the model.",
@@ -576,7 +546,6 @@ if __name__ == "__main__":
         max_rounds=args.max_rounds,
         max_questions=args.max_questions,
         use_history=args.use_history,
-        use_cache=args.use_cache,
         use_captain_board=args.use_captain_board,
         output_dir=args.output_dir,
     )

--- a/battleship/spotters.py
+++ b/battleship/spotters.py
@@ -35,14 +35,17 @@ class Spotter(Agent):
         index_counter=None,
         round_id=None,
         spotter_benchmark=None,
+        json_path=None,
+        completions_dir=None,
     ):
         self.board_id = board_id
         self.board_experiment = board_experiment
         self.temperature = temperature
         self.spotter_benchmark = spotter_benchmark
+        self.json_path = json_path
+        self.completions_dir = completions_dir
         self.client = get_openai_client()
 
-        # Use proper Agent initialization to handle model string and cache path
         super().__init__(
             seed=None,
             model_string=model_string,

--- a/battleship/spotters.py
+++ b/battleship/spotters.py
@@ -56,7 +56,7 @@ class Spotter(Agent):
     def answer(
         self, question: Question, occ_tiles: np.ndarray, history: List[dict] = None
     ) -> Answer:
-        answer, action_data = self.answer_strategy.answer_question(
+        answer, action_data = self.answer_strategy(
             question=question,
             occ_tiles=occ_tiles,
             history=history,
@@ -90,7 +90,7 @@ class DirectAnswerStrategy(AnswerStrategy):
         self.use_cot = use_cot
         self.client = get_openai_client()
 
-    def answer_question(
+    def __call__(
         self,
         question: Question,
         occ_tiles: np.ndarray,
@@ -229,7 +229,7 @@ class CodeAnswerStrategy(AnswerStrategy):
         else:
             return None
 
-    def answer_question(
+    def __call__(
         self,
         question: Question,
         occ_tiles: np.ndarray,

--- a/battleship/spotters.py
+++ b/battleship/spotters.py
@@ -35,8 +35,6 @@ class Spotter(Agent):
         index_counter=None,
         round_id=None,
         spotter_benchmark=None,
-        stage_dir=None,
-        prompts_dir=None,
     ):
         self.board_id = board_id
         self.board_experiment = board_experiment
@@ -52,8 +50,6 @@ class Spotter(Agent):
             decision_counter=decision_counter,
             index_counter=index_counter,
             round_id=round_id,
-            stage_dir=stage_dir,
-            prompts_dir=prompts_dir,
         )
 
     @abstractmethod

--- a/battleship/spotters.py
+++ b/battleship/spotters.py
@@ -34,8 +34,6 @@ class Spotter(Agent):
         model_string="gpt-4o",
         temperature=None,
         use_cot=False,
-        decision_counter=None,
-        index_counter=None,
         round_id=None,
         spotter_benchmark=None,
         json_path=None,
@@ -51,8 +49,6 @@ class Spotter(Agent):
             seed=None,
             model_string=model_string,
             use_cot=use_cot,
-            decision_counter=decision_counter,
-            index_counter=index_counter,
             round_id=round_id,
             json_path=json_path,
         )
@@ -60,7 +56,6 @@ class Spotter(Agent):
     def answer(
         self, question: Question, occ_tiles: np.ndarray, history: List[dict] = None
     ) -> Answer:
-        self.index_counter.increment_counter()
         answer, action_data = self.answer_strategy.answer_question(
             question=question,
             occ_tiles=occ_tiles,
@@ -86,11 +81,8 @@ class DirectAnswerStrategy(AnswerStrategy):
         model_string="gpt-4o",
         temperature=None,
         use_cot=False,
-        index_counter=None,
     ):
-        super().__init__(
-            index_counter=index_counter,
-        )
+        super().__init__()
         self.board_id = board_id
         self.board_experiment = board_experiment
         self.model_string = model_string
@@ -147,7 +139,6 @@ class DirectAnswerStrategy(AnswerStrategy):
 
         # Create ActionData object
         action_data = ActionData(
-            index=self.index_counter.increment_counter(),
             action="answer",
             prompt=str(prompt),
             completion=completion.model_dump() if completion else None,
@@ -166,11 +157,8 @@ class CodeAnswerStrategy(AnswerStrategy):
         model_string="gpt-4o",
         temperature=None,
         use_cot=False,
-        index_counter=None,
     ):
-        super().__init__(
-            index_counter=index_counter,
-        )
+        super().__init__()
         self.board_id = board_id
         self.board_experiment = board_experiment
         self.model_string = model_string
@@ -267,7 +255,6 @@ class CodeAnswerStrategy(AnswerStrategy):
 
         # Create ActionData object
         action_data = ActionData(
-            index=self.index_counter.increment_counter(),
             action="answer",
             prompt="Code translation and execution",  # Could be more detailed
             question=question,
@@ -296,7 +283,6 @@ class DirectSpotterModel(Spotter):
             "temperature": kwargs.get("temperature"),
             "use_cot": kwargs.get("use_cot", False),
             "json_path": kwargs.get("json_path"),
-            "index_counter": kwargs.get("index_counter"),
         }
 
         answer_strategy = DirectAnswerStrategy(**strategy_kwargs)
@@ -317,7 +303,6 @@ class CodeSpotterModel(Spotter):
             "temperature": kwargs.get("temperature"),
             "use_cot": kwargs.get("use_cot", False),
             "json_path": kwargs.get("json_path"),
-            "index_counter": kwargs.get("index_counter"),
         }
 
         answer_strategy = CodeAnswerStrategy(**strategy_kwargs)
@@ -348,7 +333,6 @@ def create_spotter(
             model_string=model_string,
             temperature=temperature,
             use_cot=use_cot,
-            index_counter=index_counter,
         )
     elif spotter_type == "CodeSpotterModel":
         answer_strategy = CodeAnswerStrategy(
@@ -357,7 +341,6 @@ def create_spotter(
             model_string=model_string,
             temperature=temperature,
             use_cot=use_cot,
-            index_counter=index_counter,
         )
     else:
         raise ValueError(f"Unknown spotter type: {spotter_type}")
@@ -369,8 +352,6 @@ def create_spotter(
         model_string=model_string,
         temperature=temperature,
         use_cot=use_cot,
-        decision_counter=decision_counter,
-        index_counter=index_counter,
         round_id=round_id,
         spotter_benchmark=spotter_benchmark,
         json_path=json_path,

--- a/battleship/spotters.py
+++ b/battleship/spotters.py
@@ -153,7 +153,6 @@ class DirectAnswerStrategy(AnswerStrategy):
             completion=completion.model_dump() if completion else None,
             question=question,
             answer=answer,
-            timestamp=time.time(),
         )
 
         return answer, action_data
@@ -273,7 +272,6 @@ class CodeAnswerStrategy(AnswerStrategy):
             prompt="Code translation and execution",  # Could be more detailed
             question=question,
             answer=answer,
-            timestamp=time.time(),
         )
 
         return answer, action_data

--- a/battleship/strategies.py
+++ b/battleship/strategies.py
@@ -25,7 +25,7 @@ class BaseStrategy(ABC):
 
 class DecisionStrategy(BaseStrategy):
     @abstractmethod
-    def make_decision(
+    def __call__(
         self, state, history, questions_remaining, moves_remaining, sunk
     ) -> Tuple[Decision, "ActionData"]:
         pass
@@ -33,7 +33,7 @@ class DecisionStrategy(BaseStrategy):
 
 class MoveStrategy(BaseStrategy):
     @abstractmethod
-    def make_move(
+    def __call__(
         self, state, history, sunk, questions_remaining, moves_remaining, constraints
     ) -> Tuple[Tuple[int, int], "ActionData"]:
         pass
@@ -41,7 +41,7 @@ class MoveStrategy(BaseStrategy):
 
 class QuestionStrategy(BaseStrategy):
     @abstractmethod
-    def ask_question(
+    def __call__(
         self, state, history, sunk, questions_remaining, moves_remaining
     ) -> Tuple["Question", "ActionData"]:
         pass
@@ -49,7 +49,7 @@ class QuestionStrategy(BaseStrategy):
 
 class AnswerStrategy(BaseStrategy):
     @abstractmethod
-    def answer_question(
+    def __call__(
         self, question, occ_tiles, history=None
     ) -> Tuple["Answer", "ActionData"]:
         pass

--- a/battleship/strategies.py
+++ b/battleship/strategies.py
@@ -1,0 +1,55 @@
+import json
+import os
+import time
+from abc import ABC
+from abc import abstractmethod
+from typing import Dict
+from typing import List
+from typing import Tuple
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from battleship.agents import get_openai_client
+from battleship.game import Decision
+
+# Forward declarations to avoid circular imports
+if TYPE_CHECKING:
+    from battleship.agents import ActionData, Question, Answer
+
+
+class BaseStrategy(ABC):
+    def __init__(self, index_counter=None):
+        self.index_counter = index_counter
+
+
+class DecisionStrategy(BaseStrategy):
+    @abstractmethod
+    def make_decision(
+        self, state, history, questions_remaining, moves_remaining, sunk
+    ) -> Tuple[Decision, "ActionData"]:
+        pass
+
+
+class MoveStrategy(BaseStrategy):
+    @abstractmethod
+    def make_move(
+        self, state, history, sunk, questions_remaining, moves_remaining, constraints
+    ) -> Tuple[Tuple[int, int], "ActionData"]:
+        pass
+
+
+class QuestionStrategy(BaseStrategy):
+    @abstractmethod
+    def ask_question(
+        self, state, history, sunk, questions_remaining, moves_remaining
+    ) -> Tuple["Question", "ActionData"]:
+        pass
+
+
+class AnswerStrategy(BaseStrategy):
+    @abstractmethod
+    def answer_question(
+        self, question, occ_tiles, history=None
+    ) -> Tuple["Answer", "ActionData"]:
+        pass

--- a/battleship/strategies.py
+++ b/battleship/strategies.py
@@ -19,8 +19,8 @@ if TYPE_CHECKING:
 
 
 class BaseStrategy(ABC):
-    def __init__(self, index_counter=None):
-        self.index_counter = index_counter
+    def __init__(self):
+        pass
 
 
 class DecisionStrategy(BaseStrategy):


### PR DESCRIPTION
Overhauled code and file structure to improve extensibility.

## Main changes
- Renamed captain benchmark file to `run_captain_benchmarks.py` for consistency with spotter benchmark
- Refactored experiment output file structure (see below)
  - `BattleshipGame.save()` saves core game history as JSON
  - `Captain` / `Spotter` have subclass-specific save logic for prompts and completions
  - Removed `CacheData` and extraneous output files
- Refactored `Spotter` class to use `Strategy` objects, in line with `Captain` class

## New directory structure

```
experiments/collaborative/captain_benchmarks/run_YYYY_MM_DD_HH_MM_SS/
├── command.txt                    # Command used to run the script
├── run.log                       # Logging output
├── summary.json                  # Aggregated results from all games
└── rounds/                       # Individual game rounds
    ├── round_{uuid_8char}/       # Unique round ID
    │   ├── captain/
    │   │   └── captain.json      # Captain config/state
    │   ├── spotter/
    │   │   └── spotter.json      # Spotter config/state
    │   └── game.json          # Game history (saved by BattleshipGame)
    └── ...                       # Additional rounds
```

## TODOs
- Need to update `run_spotter_benchmarks.py` with new changes