### PR TITLE
Change ship tracker prompts and fast sampler logic

### DIFF
--- a/battleship/board.py
+++ b/battleship/board.py
@@ -258,11 +258,11 @@ class Board(object):
 
     def ship_tracker(self, partial_board: "Board"):
         """
-        Return a string describing the sinking status of each ship.
+        Return an array describing the sinking status of each ship.
 
-        Example: "Green ship sunk, Red ship sunk, Purple ship not yet sunk, Orange ship not yet sunk"
+        Example: [(4, None), (3, "red"), (2, "green")] implies there is a ship of length 4 that has not been sunk, a ship of length 3 that is red and has been sunk, and a ship of length 2 that is green and has been sunk.
         """
-        tracker = {}
+        tracker = []
 
         # Create reverse mapping from ship number to name
         reverse_mapping = {}
@@ -282,9 +282,9 @@ class Board(object):
                 # Determine if ship is sunk
                 if target_count > 0:
                     if target_count == state_count:
-                        tracker[ship_name] = True
+                        tracker.append((target_count, ship_name))
                     else:
-                        tracker[ship_name] = False
+                        tracker.append((target_count, None))
 
         return tracker
 

--- a/battleship/game.py
+++ b/battleship/game.py
@@ -107,26 +107,21 @@ class BattleshipGame:
 
     def next_stage(self):
         # TODO: Move string formatting logic into the Agent classes
-        sunk_string = ", ".join(
-            [
-                f"{ship}: {'sunk' if status else 'not sunk'}"
-                for ship, status in self.target.ship_tracker(self.state).items()
-            ]
-        )
+        sunk = self.target.ship_tracker(self.state)
 
         decision = self.captain.decision(
             state=self.state,
             history=self.history,
             questions_remaining=self.max_questions - self.question_count,
             moves_remaining=self.max_moves - self.move_count,
-            sunk=sunk_string,
+            sunk=sunk,
         )
 
         if decision == Decision.QUESTION:
             q = self.captain.question(
                 self.state,
                 self.history,
-                sunk_string,
+                sunk,
                 questions_remaining=self.max_questions - self.question_count,
                 moves_remaining=self.max_moves - self.move_count,
                 constraints=self.captain.sampling_constraints,
@@ -152,7 +147,7 @@ class BattleshipGame:
             coords = self.captain.move(
                 self.state,
                 self.history,
-                sunk_string,
+                sunk,
                 questions_remaining=self.max_questions - self.question_count,
                 moves_remaining=self.max_moves - self.move_count,
                 constraints=self.captain.sampling_constraints,

--- a/battleship/prompting.py
+++ b/battleship/prompting.py
@@ -290,8 +290,9 @@ PROMPT_TASK_QUESTION = (
 
 PROMPT_QUESTIONS_AND_MOVES_REMAINING = "You can ask {q_remaining} more questions over the course of the game, and can fire {moves_remaining} more times."
 
-PROMPT_SHIP_STATUS = "Ship Status: {sunk}"
+PROMPT_SHIP_LENGTHS = "The ships on the board are of the following lengths: {lengths}."
 
+PROMPT_SHIP_STATUS = "A ship of length {length} {sunk_status}."
 
 class CaptainPrompt(BasePrompt):
     """Prompt for generating decisions during a game of Battleship."""
@@ -336,7 +337,13 @@ class CaptainPrompt(BasePrompt):
             q_remaining=self.questions_remaining, moves_remaining=self.moves_remaining
         )
 
-        postfix += "\n" + PROMPT_SHIP_STATUS.format(sunk=self.sunk)
+        ship_lengths = [sunk[0] for sunk in self.sunk]
+        postfix += "\n" + PROMPT_SHIP_LENGTHS.format(lengths=ship_lengths)
+
+        postfix += "\n"
+        for ship_length, ship_color_or_none in self.sunk:
+            sunk_string = "has been sunk. It was the {ship_color_or_none} ship." if ship_color_or_none else "has not yet been sunk."
+            postfix += PROMPT_SHIP_STATUS.format(length=ship_length, sunk_status=sunk_string)
 
         # Add CoT instruction if needed
         if self.use_cot:


### PR DESCRIPTION
This pull request refactors how ship status is tracked and presented throughout the Battleship codebase. The main improvement is changing the `ship_tracker` output from a string-based summary to a structured array e.g. [(3, None), (4, "green")].

Also modified prompts in `battleship/prompting.py` to display ship lengths and individual ship status using the new structured data, meaning that data is only string-serialized at prompt time and always kept as a structured array before that. 